### PR TITLE
fix plugin cannot be loaded for module "QtQuick.Layouts"

### DIFF
--- a/Components/LayoutPanel.qml
+++ b/Components/LayoutPanel.qml
@@ -1,5 +1,6 @@
 import QtQuick 2.15
 import QtQuick.Controls 2.15
+import QtQml.Models 2.1
 
 Item {
     implicitHeight: layoutButton.height

--- a/Components/SessionPanel.qml
+++ b/Components/SessionPanel.qml
@@ -1,5 +1,6 @@
 import QtQuick 2.15
 import QtQuick.Controls 2.15
+import QtQml.Models 2.1
 
 Item {
     property int session: sessionList.currentIndex

--- a/Components/UserList.qml
+++ b/Components/UserList.qml
@@ -1,7 +1,7 @@
 import QtQuick 2.15
-import QtQuick.Layouts 2.15
 import QtQuick.Controls 2.15
-import Qt5Compat.GraphicalEffects
+import QtGraphicalEffects 1.15
+import QtQml.Models 2.1
 
 Rectangle {
     id: container

--- a/Components/UserPanel.qml
+++ b/Components/UserPanel.qml
@@ -1,7 +1,7 @@
 import QtQuick 2.15
 import QtQuick.Window 2.15
 import QtQuick.Controls 2.15
-import Qt5Compat.GraphicalEffects
+import QtGraphicalEffects 1.15
 
 FocusScope {
 

--- a/Main.qml
+++ b/Main.qml
@@ -1,7 +1,8 @@
 import QtQuick 2.15
 import QtQuick.Controls 2.15
-import QtQuick.Layouts 2.15
-import "Components"
+import QtQuick.Window 2.15
+import SddmComponents 2.0
+import "./Components"
 
 Item {
     id: root


### PR DESCRIPTION
## Changes
- remove `QtQuick.Layouts` imports
- change `Qt5Compat.GraphicalEffects` to `QtGraphicalEffects`
- add `QtQml.Models` for `DelegateModel`
- add `QtQuick.Window` for `Screen`
- add `SddmComponents` import

## Log:
```
[20:00:51.399] (WW) GREETER: file:///home/krisanapon/Documents/test/win10-sddm-theme//Main.qml:3:1: plugin cannot be loaded for module "QtQuick.Layouts": Cannot protect module QtQuick.Layouts 2 as it was never registered 
     import QtQuick.Layouts 2.15 
     ^
[20:00:51.399] (WW) GREETER: file:///home/krisanapon/Documents/test/win10-sddm-theme//Main.qml:3:1: plugin cannot be loaded for module "QtQuick.Layouts": Cannot protect module QtQuick.Layouts 2 as it was never registered 
     import QtQuick.Layouts 2.15 
     ^
[20:00:51.399] (WW) GREETER: Fallback to embedded theme
[20:00:51.415] (WW) GREETER: file:///usr/lib/x86_64-linux-gnu/qt5/qml/SddmComponents/LayoutBox.qml:35:5: QML Connections: Implicitly defined onFoo properties in Connections are deprecated. Use this syntax instead: function onFoo(<arguments>) { ... }
[20:00:51.463] (WW) GREETER: qrc:/theme/Main.qml:41:5: QML Connections: Implicitly defined onFoo properties in Connections are deprecated. Use this syntax instead: function onFoo(<arguments>) { ... }
[20:00:51.463] (II) GREETER: Adding view for "HDMI-2" QRect(0,0 1920x1080)
[20:00:51.535] (WW) GREETER: qrc:/QtQuick/VirtualKeyboard/content/InputPanel.qml:138:5: Type Keyboard unavailable 
         Keyboard { 
         ^
[20:00:51.536] (WW) GREETER: qrc:/QtQuick/VirtualKeyboard/content/components/Keyboard.qml:33:1: module "QtQuick.Layouts" is not installed 
     import QtQuick.Layouts 1.0 
     ^
```

## Story
I installed this sddm theme from kde plasma, but it's only show red error message, so I tested it using `sddm-greeter --theme win10-sddm-theme --test-mode`.
I searched google and asked chatgpt, and ended with installing more debian packages including qml6-module-qt5compat-graphicaleffects. The result is error, so I decided to contribute to the source.